### PR TITLE
Contribuidores en Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Gracias a nuestros patrocinadores contaremos con bebidas y coffee break para los
 
 <!-- ### Equipo organizador -->
 
+### Contribuidores
+
+<a href="https://github.com/FunPythonEC/Hacktoberfest-GYE-2022/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=FunPythonEC/Hacktoberfest-GYE-2022" />
+</a>
+
 ### Código de Conducta
 
 Los eventos de Hacktoberfest son amigables, abiertos, e inclusivos. Por favor leer [nuestro código de conducta](CODE_OF_CONDUCT.md) antes de asistir al evento. Happy hacking!


### PR DESCRIPTION
# Descripción
Se añadió una imagen mostrando los contribuidores del repositorio usando [contrib_rocks](https://contrib.rocks/preview?repo=FunPythonEC%2FHacktoberfest-GYE-2022).